### PR TITLE
Support for Google and Bing components

### DIFF
--- a/modules/google.js
+++ b/modules/google.js
@@ -275,6 +275,7 @@ zoekplaatje.register_module(
                         type: 'few-matches',
                         title: '',
                         description: text_from_childless_children(item)
+                    }
                 } else if (item.matches('#oFNiHe') && item.querySelector('div[data-key=filter]')) {
                     // Safe search bar
                     parsed_item = {

--- a/modules/google.js
+++ b/modules/google.js
@@ -249,7 +249,7 @@ zoekplaatje.register_module(
 
 
                 // todo: for some reason, the whole #rhs knowledge graph side bar gets selected sometimes, probably
-                //  because it gets loaded in as a 'correct' subelement and then moved around later depending on
+                //  because it gets loaded in as a 'correct' sub-element and then moved around later depending on
                 //  the viewport? Hard-code a skip for now!
                 if (item.matches("#rhs")) {
                     console.log('Skipping #rhs div')
@@ -268,6 +268,14 @@ zoekplaatje.register_module(
                         ...parsed_item,
                         type: 'did-you-mean',
                         title: title
+                    }
+                } else if (item.querySelector('.uzjuFc')) {
+                    // "Looks like there aren't any great matches" box
+                    parsed_item = {
+                        ...parsed_item,
+                        type: 'few-matches',
+                        title: '',
+                        description: text_from_childless_children(item)
                     }
                 } else if (item.matches('g-scrolling-carousel') && closest_parent(item, '#appbar')) {
                     // suggested topic/search card on top of the page

--- a/modules/google.js
+++ b/modules/google.js
@@ -551,11 +551,19 @@ zoekplaatje.register_module(
                         type: 'stock-widget',
                         description: text_from_childless_children(item)
                     }
+                } else if (item.querySelector('#tw-ob') || item.querySelector('#tw-gtlink')) {
+                    // Translate widget
+                    parsed_item = {
+                        ...parsed_item,
+                        type: 'translate-widget',
+                        title: '',
+                        description: text_from_childless_children(item)
+                    }
                 } else if (item.matches('.xpdbox')) {
                     // dictionary widget
                     parsed_item = {
                         ...parsed_item,
-                        type: 'dictionary-widget',
+                        type: 'translate-widget',
                         title: safe_prop(item.querySelector('.data-attrid[EntryHeader]'), 'innerText'),
                         description: text_from_childless_children(item.querySelector('.lr_container > div[jsslot]'), 'innerText'),
                     }

--- a/modules/google.js
+++ b/modules/google.js
@@ -1,7 +1,7 @@
 zoekplaatje.register_module(
     'Google',
     'google.com',
-    function (response, source_platform_url, source_url, nav_index) {
+    function (response, source_platform_url, source_url) {
         //console.log(response)
         let results = [];
         let results_sidebar = [];
@@ -15,7 +15,7 @@ zoekplaatje.register_module(
             return [];
         }
 
-        // we're gonna need these to parse the data
+        // we're going to need these to parse the data
         let path = source_url.split('/').slice(3).join('/');
         let now = moment();
         let index = 1;
@@ -75,10 +75,8 @@ zoekplaatje.register_module(
                 return false;
             } if (el.textContent.trim() !== "") {
                 return true;
-            } if (el.childNodes.length > 0) {
-                return true;
-            }
-            return false;
+            } return el.childNodes.length > 0;
+
         }
 
         function text_from_childless_children(container) {
@@ -119,6 +117,8 @@ zoekplaatje.register_module(
 
         // 'did you mean' search correction; always on top
         item_selectors.push('#fprs');
+        // ..which can also loop like this:
+        item_selectors.push('#center_col > #taw')
         // 'app bar' cards on top
         item_selectors.push('#appbar g-scrolling-carousel')
 
@@ -461,7 +461,7 @@ zoekplaatje.register_module(
                     // seems to be LLM-generated, to some extent
                     parsed_item = {
                         ...parsed_item,
-                        type: 'related-questions-widget',
+                        type: 'related-questions',
                         // use list of questions as description
                         description: Array.from(item.querySelectorAll('.related-question-pair')).map(question => question.getAttribute('data-q')).join(', '),
                         title: safe_prop(item.querySelector('div[role=heading]'), 'innerText')
@@ -536,7 +536,7 @@ zoekplaatje.register_module(
                         type: 'stock-chart',
                         description: Array.from(item.querySelectorAll('g-card-section[class] > div')).map(div => div.innerText.trim()).join(', ')
                     }
-                } else if (item.querySelector('div[data-attrid="kc:/business/issuer:stock quote]"')) {
+                } else if (item.querySelector('div[data-attrid="kc:/business/issuer:stock quote"]')) {
                     // Small stock widget
                     parsed_item = {
                         ...parsed_item,
@@ -671,7 +671,7 @@ zoekplaatje.register_module(
 
                     parsed_item = {
                         ...parsed_item,
-                        type: 'related-queries-widget',
+                        type: 'related-queries',
                         title: safe_prop(item.querySelector('div[role=heading]'), 'innerText'),
                         description: description
                     }


### PR DESCRIPTION
This PR adds support for (most) components/widgets on Google and Bing.

What this does not support (yet):
- Getting the contents of Google AI Overview answers
- Getting the contents of 'full' Copilot responses (only shown on Bing when logged in)
- All URLs for all widgets
- Fact-check boxes on Google
- 'Datasets' widget for Google
- 'Speak with someone today' widget for Google
- Q/A widget for Bing
- 'Showing studies for...' widget on Bing
- Blurred videos/images widget on Bing
- 'Recipes' widget on Bing
- 'Expert opinion' widget on on Bing

Some hard-to-reproduce bugs (for future notice):
Bing
- Wiki widgets and 'also searched for' in the right sidebar are sometimes omitted
Google
- "wiki-widget" isn't always captured properly
- Empty unknowns at the bottom of the page show up sometimes, likely ads?
