### PR TITLE
gemini-responses

### DIFF
--- a/modules/google.js
+++ b/modules/google.js
@@ -4,7 +4,6 @@ zoekplaatje.register_module(
     function (response, source_platform_url, source_url) {
         //console.log(response)
         let results = [];
-        let results_gemini = []
         let results_sidebar = [];
 
         // source_platform_url = URL in browser

--- a/modules/google.js
+++ b/modules/google.js
@@ -168,6 +168,11 @@ zoekplaatje.register_module(
         // we consider different cards as different items
         if (resultpage.querySelectorAll('.M8OgIe').length === 1) {
             item_selectors.push('.WJXODe > div, .e6hL7d > div');
+            item_selectors.push('' +
+                '#Odp5De div[data-attrid=CoreAnswerModuleHeader],' +
+                '#Odp5De .Qc895c,' +
+                '#Odp5De div[style][data-hveid],' +
+                '#Odp5De g-scrolling-carousel')
         }
 
         // ads are elsewhere in the hierarchy and, for a change, conveniently labeled
@@ -310,7 +315,14 @@ zoekplaatje.register_module(
                         type: 'suggested-topic-card',
                         description: text_from_childless_children(item)
                     }
-                } else if (item.matches(".HdbW6")) {
+                } else if (item.matches('div[data-attrid=CoreAnswerModuleHeader]')) {
+                    // entity answers, spanning the top of the page
+                    parsed_item = {
+                        ...parsed_item,
+                        type: 'page-answer',
+                        title: Array.from(item.querySelectorAll('div:first-of-type a > span, div:first-of-type span > span')).map(h => h.innerText).join(' ')
+                    }
+                } else if (item.matches('.HdbW6')) {
                     // page subject
                     let description = ''
                     if (item.querySelector('div[data-attrid=subtitle]')) {
@@ -353,6 +365,12 @@ zoekplaatje.register_module(
                         type: 'info-card' + subtype,
                         title: Array.from(item.querySelectorAll('div[role=heading], span[role=heading], .pe7FNb')).map(t => safe_prop(t, 'innerText')).join(', '),
                         description: text_from_childless_children(item)
+                    }
+                } else if (item.querySelector('div[data-attrid=CoreAnswerImageResult]')) {
+                    // info card with just images
+                    parsed_item = {
+                        ...parsed_item,
+                        type: 'info-card-images'
                     }
                 } else if (item.querySelector('#sports-app')) {
                     // widget with info about some sports club

--- a/modules/google.js
+++ b/modules/google.js
@@ -135,7 +135,7 @@ zoekplaatje.register_module(
                 // multiple results under #rso, else we'll fetch the results with the kp-wp-tab selectors
                 item_selectors.push('#center_col #rso > div')
             }
-        } else {
+        } else if (!gemini_response) {
             item_selectors.push('body > div > div:not(#tvcap)');
         }
 
@@ -218,7 +218,6 @@ zoekplaatje.register_module(
 
             for (let gemini_item of gemini_items) {
                 if (gemini_item.matches('span[data-huuid]')) {
-                    console.log("GEMINI TEXT")
                     // Gemini text
                     const gemini_text_part = safe_prop(gemini_item, 'innerText')
                     if (gemini_text_part) {
@@ -226,7 +225,6 @@ zoekplaatje.register_module(
                     }
                 } else if (gemini_item.matches('div[data-subtree="msc"]')) {
                     // Gemini links
-                    console.log("GEMINI LINKS")
                     const gemini_links_tmp = Array.from(gemini_item.querySelectorAll('a')).map(a => a.getAttribute('href').split('#:~:text')[0])
                     if (gemini_links_tmp.length > 0) {
                         gemini_links = gemini_links_tmp  // These are always complete, so we can just store them
@@ -251,6 +249,13 @@ zoekplaatje.register_module(
                 link: '----------------------'
             })*/
             for (let item of result_items) {
+
+                // for debugging:
+                // for (const item_selector of item_selectors) {
+                //     if (item.matches(item_selector.trim())) {
+                //         console.log("Found item with selector: " + item_selector)
+                //     }
+                // }
 
                 let parsed_item = {
                     id: now.format('x') + '-' + index,
@@ -732,6 +737,7 @@ zoekplaatje.register_module(
                     // unrecognised result type
                     // consider logging and fixing...!
                     console.log('unknown', item)
+
                     parsed_item = {
                         ...parsed_item,
                         description: text_from_childless_children(item)

--- a/modules/google.js
+++ b/modules/google.js
@@ -167,6 +167,11 @@ zoekplaatje.register_module(
         // we consider different cards as different items
         if (resultpage.querySelectorAll('.M8OgIe').length === 1) {
             item_selectors.push('.WJXODe > div, .e6hL7d > div');
+            item_selectors.push('' +
+                '#Odp5De div[data-attrid=CoreAnswerModuleHeader],' +
+                '#Odp5De .Qc895c,' +
+                '#Odp5De div[style][data-hveid],' +
+                '#Odp5De g-scrolling-carousel')
         }
 
         // ads are elsewhere in the hierarchy and, for a change, conveniently labeled
@@ -308,7 +313,14 @@ zoekplaatje.register_module(
                         type: 'suggested-topic-card',
                         description: text_from_childless_children(item)
                     }
-                } else if (item.matches(".HdbW6")) {
+                } else if (item.matches('div[data-attrid=CoreAnswerModuleHeader]')) {
+                    // entity answers, spanning the top of the page
+                    parsed_item = {
+                        ...parsed_item,
+                        type: 'page-answer',
+                        title: Array.from(item.querySelectorAll('div:first-of-type a > span, div:first-of-type span > span')).map(h => h.innerText).join(' ')
+                    }
+                } else if (item.matches('.HdbW6')) {
                     // page subject
                     let description = ''
                     if (item.querySelector('div[data-attrid=subtitle]')) {
@@ -351,6 +363,12 @@ zoekplaatje.register_module(
                         type: 'info-card' + subtype,
                         title: Array.from(item.querySelectorAll('div[role=heading], span[role=heading], .pe7FNb')).map(t => safe_prop(t, 'innerText')).join(', '),
                         description: text_from_childless_children(item)
+                    }
+                } else if (item.querySelector('div[data-attrid=CoreAnswerImageResult]')) {
+                    // info card with just images
+                    parsed_item = {
+                        ...parsed_item,
+                        type: 'info-card-images'
                     }
                 } else if (item.querySelector('#sports-app')) {
                     // widget with info about some sports club

--- a/modules/google.js
+++ b/modules/google.js
@@ -100,9 +100,6 @@ zoekplaatje.register_module(
 
         let item_selectors = [];
 
-        // AI overview parts
-        let gemini_selectors = 'span[data-huuid], div[data-subtree="msc"]'
-
         // 'did you mean' search correction and stuff like SafeSearch; always on top
         item_selectors.push('#oFNiHe');
 
@@ -203,7 +200,6 @@ zoekplaatje.register_module(
             item_selectors.push('#rhs > div[id], #rhs > block-component');
         }
 
-
         const results_selector = item_selectors.join(', ');
         console.log("Selecting items with the following CSS selectors:")
         console.log(results_selector);
@@ -211,19 +207,26 @@ zoekplaatje.register_module(
         // go through results in DOM, using the selectors defined above...
         let result_items = resultpage.querySelectorAll(results_selector);
 
-        let gemini_text = []
         let gemini_links = []
         let query = ''
 
         // Manage Gemini responses differently; store data per element, and group later.
+        let gemini_selectors = 'span[data-huuid], div[data-subtree="msc"]'
+        let gemini_text = []
+
         if (gemini_response) {
             let gemini_items = resultpage.querySelectorAll(gemini_selectors);
 
             for (let gemini_item of gemini_items) {
                 if (gemini_item.matches('span[data-huuid]')) {
                     // Gemini text
-                    const gemini_text_part = safe_prop(gemini_item, 'innerText')
+                    console.log(gemini_item)
+                    let gemini_text_part = safe_prop(gemini_item, 'innerText')
                     if (gemini_text_part) {
+                        // Add newline if this is a header
+                        if (gemini_item.querySelector("strong") || gemini_item.querySelector("span[role='heading']")) {
+                            gemini_text_part += "\n"
+                        }
                         gemini_text.push(gemini_text_part)
                     }
                 } else if (gemini_item.matches('div[data-subtree="msc"]')) {
@@ -812,6 +815,7 @@ zoekplaatje.register_module(
                     type: 'ai-overview',
                     domain: '',
                     title: '',
+                    published: '',
                     description: gemini_text.join(" "),
                     link: gemini_links.join(", "),
                     section: 'top'

--- a/modules/google.js
+++ b/modules/google.js
@@ -34,6 +34,7 @@ zoekplaatje.register_module(
             title: 'h3',
             link: 'span > a',
             description: 'div.VwiC3b, div.ITZIwc, div.xpdopen div.wDYxhc',  // ugh :(
+            published: 'span.YrbPuc',
         };
 
         function closest_parent(node, selector) {
@@ -221,6 +222,7 @@ zoekplaatje.register_module(
                     type: 'unknown',
                     domain: '',
                     title: '',
+                    published: '',
                     description: '',
                     link: ''
                 };
@@ -478,6 +480,7 @@ zoekplaatje.register_module(
                         ...parsed_item,
                         title: safe_prop(item.querySelector(selectors.title), 'innerText'),
                         link: link,
+                        published: safe_prop(item.querySelector(selectors.published), 'innerText').replace(/â€".*$/g, '').replace(/—.*$/g, '').trim(), // remove the '—' and 'â€"' from the end of the date
                         description: safe_prop(item.querySelector(selectors.description), 'innerText')
                     }
                 } else if (item.querySelector('div[role=listitem][data-attrid*=books]')) {

--- a/modules/google.js
+++ b/modules/google.js
@@ -360,7 +360,7 @@ zoekplaatje.register_module(
                         title: safe_prop(item.querySelector('div[role=heading]'), 'innerText'),
                         link: safe_prop(item.querySelector('a'), 'attr:href')
                     }
-                } else if (item.matches('#Odp5De')) {
+                } else if (item.querySelector('block-component .xpdopen')) {
                     // 'featured snippet' banner
                     parsed_item = {
                         ...parsed_item,
@@ -711,7 +711,11 @@ zoekplaatje.register_module(
                         link: domain_prefix + safe_prop(item.querySelector("a[href^='/search']:not(.a-no-hover-decoration)"), 'attr:href'),
                         description: Array.from(item.querySelectorAll('a.a-no-hover-decoration')).map(a => a.getAttribute('title')).join(', ')
                     }
-                } else if ((item.querySelector('div.g') || item.matches('div.g') || item.querySelector("div[data-rpos] > div[lang]")) && item.querySelector(selectors.description)) {
+                } else if (
+                    (item.querySelector('div.g')
+                        || item.matches('div.g')
+                        || item.querySelector("div[data-rpos] div[lang]"))
+                    && item.querySelector(selectors.description)) {
                     if (item.querySelector('div[role=complementary]')) {
                         // embedded sidebar item???
                         item.querySelector('div[role=complementary]').remove();

--- a/modules/google.js
+++ b/modules/google.js
@@ -362,7 +362,7 @@ zoekplaatje.register_module(
                         title: safe_prop(item.querySelector('div[role=heading]'), 'innerText'),
                         link: safe_prop(item.querySelector('a'), 'attr:href')
                     }
-                } else if (item.matches('#Odp5De')) {
+                } else if (item.querySelector('block-component .xpdopen')) {
                     // 'featured snippet' banner
                     parsed_item = {
                         ...parsed_item,
@@ -713,7 +713,11 @@ zoekplaatje.register_module(
                         link: domain_prefix + safe_prop(item.querySelector("a[href^='/search']:not(.a-no-hover-decoration)"), 'attr:href'),
                         description: Array.from(item.querySelectorAll('a.a-no-hover-decoration')).map(a => a.getAttribute('title')).join(', ')
                     }
-                } else if ((item.querySelector('div.g') || item.matches('div.g') || item.querySelector("div[data-rpos] > div[lang]")) && item.querySelector(selectors.description)) {
+                } else if (
+                    (item.querySelector('div.g')
+                        || item.matches('div.g')
+                        || item.querySelector("div[data-rpos] div[lang]"))
+                    && item.querySelector(selectors.description)) {
                     if (item.querySelector('div[role=complementary]')) {
                         // embedded sidebar item???
                         item.querySelector('div[role=complementary]').remove();


### PR DESCRIPTION
Fetch Gemini AI Overview responses on Google.

Does a rudimentary job at merging text and links in one row.

Things to consider in future updates:
- Should we add appropriate styling for the text? I.e. with lists and headers? Or just merge it?
- Should the referenced URLs be considered as separate components? Right now, they are grouped in the `links` column.
- (How) do we link the LLM-generated text to the links? This is possible with the link icons.